### PR TITLE
Feat/entity/order

### DIFF
--- a/homs/src/main/java/com/beyond/homs/contract/entity/Contract.java
+++ b/homs/src/main/java/com/beyond/homs/contract/entity/Contract.java
@@ -1,0 +1,52 @@
+package com.beyond.homs.contract.entity;
+
+import com.beyond.homs.company.entity.Company;
+import com.beyond.homs.product.entity.Product;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "contract")
+@Getter
+@NoArgsConstructor
+public class Contract {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "contract_id")
+    private Long contractId;
+
+    @Column(name = "contract_start_at", nullable = false)
+    private LocalDateTime contractStartAt;
+
+    @Column(name = "contract_stop_at", nullable = false)
+    private LocalDateTime contractStopAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Builder
+    public Contract(LocalDateTime contractStartAt, LocalDateTime contractStopAt, Company company, Product product) {
+        this.contractStartAt = contractStartAt;
+        this.contractStopAt = contractStopAt;
+        this.company = company;
+        this.product = product;
+    }
+}

--- a/homs/src/main/java/com/beyond/homs/order/data/ClaimEnum.java
+++ b/homs/src/main/java/com/beyond/homs/order/data/ClaimEnum.java
@@ -1,0 +1,5 @@
+package com.beyond.homs.order.data;
+
+public enum ClaimEnum {
+    DEFECTIVE, DAMAGE, DISSATISFIED, OTHER;
+}

--- a/homs/src/main/java/com/beyond/homs/order/data/ClaimStatusEnum.java
+++ b/homs/src/main/java/com/beyond/homs/order/data/ClaimStatusEnum.java
@@ -1,0 +1,5 @@
+package com.beyond.homs.order.data;
+
+public enum ClaimStatusEnum {
+    EXCHANGE, CANCEL
+}

--- a/homs/src/main/java/com/beyond/homs/order/entity/Claim.java
+++ b/homs/src/main/java/com/beyond/homs/order/entity/Claim.java
@@ -1,0 +1,55 @@
+package com.beyond.homs.order.entity;
+
+import com.beyond.homs.order.data.ClaimEnum;
+import com.beyond.homs.order.data.ClaimStatusEnum;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "claim")
+@Getter
+@NoArgsConstructor
+public class Claim {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "claim_id")
+    private Long claimId;
+
+    @ManyToOne
+    @JoinColumns({
+            @JoinColumn(name = "order_id", referencedColumnName = "order_id"),
+            @JoinColumn(name = "product_id", referencedColumnName = "product_id")
+    })
+    private OrderItem orderItem;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ClaimEnum reason;
+
+    @Column(length = 1024)
+    private String details;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ClaimStatusEnum status;
+
+    @Builder
+    public Claim(OrderItem orderItem, ClaimEnum reason, String details, ClaimStatusEnum status) {
+        this.orderItem = orderItem;
+        this.reason = reason;
+        this.details = details;
+        this.status = status;
+    }
+}

--- a/homs/src/main/java/com/beyond/homs/order/entity/Order.java
+++ b/homs/src/main/java/com/beyond/homs/order/entity/Order.java
@@ -1,0 +1,67 @@
+package com.beyond.homs.order.entity;
+
+import com.beyond.homs.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+/*
+* table 명을 order로 했을 때, 테이블 생성 과정에서 에러가 발생해서 order_table로 변경
+* */
+@Entity
+@Table(name = "order_table")
+@Getter
+@NoArgsConstructor
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long orderId;
+
+    @Column(name = "order_code", nullable = false, length = 1024)
+    private String orderCode;
+
+    @Column(name = "due_date", nullable = false)
+    private LocalDateTime dueDate;
+
+    @Column(name = "order_date", nullable = false)
+    @CreatedDate
+    private LocalDateTime orderDate;
+
+    @Column(name = "is_approved", nullable = false)
+    private boolean isApproved;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id")
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id2")
+    private Order orderId2;
+
+    @Column(name = "reject_reason", length = 1024)
+    private String rejectReason;
+
+    @Builder
+    public Order(String orderCode, LocalDateTime dueDate, boolean isApproved,
+                 User user, Order orderId2, String rejectReason) {
+        this.orderCode = orderCode;
+        this.dueDate = dueDate;
+        this.isApproved = isApproved;
+        this.user = user;
+        this.orderId2 = orderId2;
+        this.rejectReason = rejectReason;
+    }
+}

--- a/homs/src/main/java/com/beyond/homs/order/entity/OrderItem.java
+++ b/homs/src/main/java/com/beyond/homs/order/entity/OrderItem.java
@@ -1,0 +1,24 @@
+package com.beyond.homs.order.entity;
+
+import com.beyond.homs.product.entity.Product;
+import com.beyond.homs.product.entity.ProductCategory;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "order_item")
+@Getter
+@NoArgsConstructor
+public class OrderItem {
+    @EmbeddedId
+    private OrderItemId orderItemId;
+
+    @Builder
+    OrderItem(OrderItemId orderItemId) {
+        this.orderItemId = orderItemId;
+    }
+}

--- a/homs/src/main/java/com/beyond/homs/order/entity/OrderItemId.java
+++ b/homs/src/main/java/com/beyond/homs/order/entity/OrderItemId.java
@@ -1,0 +1,30 @@
+package com.beyond.homs.order.entity;
+
+import com.beyond.homs.product.entity.Product;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@NoArgsConstructor
+public class OrderItemId implements Serializable {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", referencedColumnName = "product_id",nullable = false)
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id", referencedColumnName = "order_id", nullable = false)
+    private Order order;
+
+    @Builder
+    public OrderItemId(Product product, Order order) {
+        this.product = product;
+        this.order = order;
+    }
+}


### PR DESCRIPTION
Order 관련 Entity 정의
Claim
- 기존 ERD에는 OrderItem의 복합키를 그대로 PK로 가져갔으나, OrderItem과 Claim이 1:N 관계로 기존 복합키에서는 Claim을 식별할 수 없어 claim_id를 추가하고 PK로 변경